### PR TITLE
Always recreate release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - run: gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || gh release create "$GITHUB_REF_NAME" --generate-notes
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
 
   pages:
     needs: release


### PR DESCRIPTION
## Summary
- Use `softprops/action-gh-release@v2` to create or update releases on tag push
- Ensures re-tagging updates the release with fresh generated notes
- Consistent with other repos (e.g. nexar-camera-api)

## Test plan
- [x] Recreate the v1.1.0 tag and verify the release is created with `--generate-notes` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)