### PR TITLE
Fix SMB permissions being overridden to 777 on macOS

### DIFF
--- a/config/smb.conf
+++ b/config/smb.conf
@@ -5,6 +5,7 @@
   log level = 1
   vfs objects = fruit
   fruit:model = TimeCapsule6,116
+  fruit:nfs_aces = no
 
 [Config]
   path = /etc/mountbox


### PR DESCRIPTION
## Summary

- Disables `fruit:nfs_aces` globally in `smb.conf` to prevent the macOS SMB2 POSIX extension from bypassing Samba's `create mask` when setting file permissions
- Without this, editing a file via Finder or terminal would change its permissions to 777, breaking files like `authorized_keys` that require 600

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)